### PR TITLE
feat: reference overview in main page description

### DIFF
--- a/components/Home.js
+++ b/components/Home.js
@@ -86,9 +86,9 @@ const Home = () => {
                 standards-compliant federated environment to enable population scale genomic and
                 phenotypic data analysis across international boundaries.{" "}
                 <Link href="/overview" passHref>
-                  <div className="text-elixirblue font-semibold hover:underline">
+                  <span className="text-elixirblue font-semibold hover:underline cursor-pointer">
                     More...
-                  </div>
+                  </span>
                 </Link>
               </div>
               <div>

--- a/components/Home.js
+++ b/components/Home.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from "react";
+import Link from "next/link";
 import TextLoop from "react-text-loop";
 import Zoom from "react-reveal/Zoom";
 import window from "global/window";
@@ -83,7 +84,12 @@ const Home = () => {
                   GA4GH
                 </a>{" "}
                 standards-compliant federated environment to enable population scale genomic and
-                phenotypic data analysis across international boundaries.
+                phenotypic data analysis across international boundaries.{" "}
+                <Link href="/overview" passHref>
+                  <div className="text-elixirblue font-semibold hover:underline">
+                    More...
+                  </div>
+                </Link>
               </div>
               <div>
                 <img src="/Earth.svg" alt="globe" width="auto" height="auto"></img>


### PR DESCRIPTION
Add `More...` reference to paragraph that links to the `overview` page

Resolves #26 

Screenshot:
![image](https://user-images.githubusercontent.com/10855418/199592303-b76422ff-6852-4b59-828a-882b701ec297.png)

