### PR TITLE
docs(admin): remove quotes in "service:" section

### DIFF
--- a/docs/guides/guide-admin/index.md
+++ b/docs/guides/guide-admin/index.md
@@ -343,8 +343,8 @@ port on the host machine at which the API is exposed. For example, with
 
 ```yaml
 service:
-    type: "NodePort"
-    node_port: "31567"
+    type: NodePort
+    node_port: 31567
 ```
 
 Kubernetes will route requests coming in to port `31567` on the host machine to


### PR DESCRIPTION
Remove double quotes from the values in the "service:" section example. With quotes my deployment wouldn't work.

## Summary by Sourcery

Documentation:
- Remove double quotes from values in the 'service:' section example in the admin guide to ensure proper deployment.