### PR TITLE
docs(sandbox): remove section headers

### DIFF
--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -8,7 +8,7 @@ worrying about infrastructure limitations or having to manage complex server
 environments. The GA4GH Cloud APIs give you access to powerful tools and
 resources that allow you to focus on your research goals, not IT.
 
-## Funnel { #funnel }
+## Funnel
 Funnel is an open-source distributed workflow execution system designed as a reference implementation 
 of the GA4GH Task Execution Service (TES) specification. Its primary purpose is to provide a standardized 
 API for running containerized computational workloads across heterogeneous infrastructure, 
@@ -19,13 +19,13 @@ submit tasks without being tied to a specific cluster scheduler or cloud platfor
 
 See [Funnel deployment](../services/funnel.md) for detailed deployment instructions.
 
-## TESK { #tesk }
+## TESK
 TESK (Task Execution Service for Kubernetes) is an open-source implementation of the 
 GA4GH Task Execution Service (TES) standard that provides a Kubernetes-native backend for executing 
 containerized scientific workloads. It is part of the ELIXIR Cloud & AAI ecosystem and serves as the 
 cloud-native counterpart to Funnel.
 
-## Poiesis { #poiesis }
+## Poiesis
 Poiesis is a cloud-native implementation of the GA4GH Task Execution Service (TES) v1.1.0 
 designed specifically for Kubernetes environments. Like TESK and Funnel, it exposes a 
 standards-compliant TES API for running containerized computational workloads, 
@@ -34,7 +34,7 @@ Kubernetes-native operations, and task handling.
 
 See [Poiesis GitHub repo](https://github.com/JaeAeich/poiesis) for detailed instructions.
 
-## Authentication with LS Login { #authentication-with-ls-login }
+## Authentication with LS Login
 Life Science Login (LS Login), also known as the Life Science Authentication and Authorization Infrastructure [(LS AAI)](https://elixir-europe.org/platforms/compute/aai), is the federated identity and access management platform used across ELIXIR and numerous European life-science research infrastructures. It provides a single authentication and authorization layer that enables researchers to access scientific services, datasets, workflows, and computational resources using their existing institutional or community identities.
 
 LS Login evolved from the original ELIXIR AAI and became the primary authentication platform in 2022 after integration with multiple European life-science infrastructures.

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -25,6 +25,8 @@ GA4GH Task Execution Service (TES) standard that provides a Kubernetes-native ba
 containerized scientific workloads. It is part of the ELIXIR Cloud & AAI ecosystem and serves as the 
 cloud-native counterpart to Funnel.
 
+See [TESK](../services/tesk.md) for detailed deployment instructions.
+
 ## Poiesis
 Poiesis is a cloud-native implementation of the GA4GH Task Execution Service (TES) v1.1.0 
 designed specifically for Kubernetes environments. Like TESK and Funnel, it exposes a 


### PR DESCRIPTION
remove section headers

## Summary by Sourcery

Documentation:
- Remove explicit anchor IDs from sandbox page section headings to rely on default markdown-generated IDs.